### PR TITLE
Fix to work on julia v0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
-julia 0.2.1
+julia 0.3
 JSON
+Compat

--- a/src/TOML.jl
+++ b/src/TOML.jl
@@ -2,6 +2,8 @@ module TOML
 
 VERSION = v"0.1.2"
 
+using Compat
+
 
 if Base.VERSION >= v"0.4.0-dev+5050"
     anchored_regex(r) = Regex(r, Base.PCRE.ANCHORED, 0)
@@ -32,7 +34,7 @@ type ParserState
                 "(no method convert(Type{UTF8String}, $T))."))
         end
         BOM = length(subject) > 0 && subject[1] == '\ufeff'  ? true : false
-        maintbl = (UTF8String => Any)[]
+        maintbl = Dict{UTF8String,Any}()
         new(
             subject,
             BOM ? 4 : 1,      # index. Strip the BOM if present.
@@ -100,7 +102,7 @@ function table (state::ParserState)
                 _error("Key \"$k\" already defined", state)
             end
         else
-            tbl[k] = (UTF8String => Any)[]
+            tbl[k] = Dict{UTF8String,Any}()
             tbl = tbl[k]
         end
     end
@@ -139,16 +141,16 @@ function table_array (state::ParserState)
                 if !isa(tbl[k], Array{Dict{UTF8String, Any}, 1})
                     _error("Attempt to overwrite value with array", state)
                 end
-                push!(tbl[k], (UTF8String => Any)[])
+                push!(tbl[k], Dict{UTF8String,Any}())
                 tbl = last(tbl[k])
                 break
             end
         else
             if i < length(keys)
-                tbl[k] = (UTF8String => Any)[]
+                tbl[k] = Dict{UTF8String,Any}()
                 tbl = tbl[k]
             else # we're done
-                tbl[k] = [(UTF8String=>Any)[]]
+                tbl[k] = [Dict{UTF8String,Any}()]
                 tbl = last(tbl[k])
                 break
             end
@@ -209,7 +211,7 @@ function value (state)
 end
 
 
-valid_escape = [
+valid_escape = @compat Dict{Char,Char}(
     '0'  => '\0',
     '"'  => '"',
     '\\' => '\\',
@@ -219,7 +221,7 @@ valid_escape = [
     'n'  => '\n',
     'r'  => '\r',
     't'  => '\t',
-]
+)
 
 function string_value (state::ParserState)
     buf = (Char)[]
@@ -283,10 +285,6 @@ function numeric_value (state::ParserState)
     try
         numrepr = string(acc...)
         num = parsenum(NumTyp, numrepr)
-        # in Julia v0.2 `parseint()` doesn't detect overflows, but `parse()` does.
-        Base.VERSION < v"0.3-prerelease" &&
-            NumTyp == Int64 &&
-            Base.parse(numrepr)
     catch err
         _error("Couldn't parse number ($(repr(err)))", state)
     end
@@ -295,7 +293,7 @@ end
 
 
 function array_value(state)
-    ary = {}
+    ary = Any[]
     local typ = Any
     while next_non_comment!(state) != ']' # covers empty arrays and trailing comas
         state.index -= 1

--- a/src/TOML.jl
+++ b/src/TOML.jl
@@ -3,6 +3,13 @@ module TOML
 VERSION = v"0.1.2"
 
 
+if Base.VERSION >= v"0.4.0-dev+5050"
+    anchored_regex(r) = Regex(r, Base.PCRE.ANCHORED, 0)
+else
+    anchored_regex(r) = Regex(r, Base.PCRE.ANCHORED)
+end
+
+
 include("datetime.jl")
 
 
@@ -65,7 +72,7 @@ function parse(subject::Union(String, Array{Uint8, 1}))
 end
 
 
-const table_pattern = Regex("[ \t]*([^ \t\r\n][^\]\r\n]*)\]", Base.PCRE.ANCHORED)
+const table_pattern = anchored_regex("[ \t]*([^ \t\r\n][^\]\r\n]*)\]")
 
 function table (state::ParserState)
     m = match(table_pattern, state.subject, state.index)
@@ -103,7 +110,7 @@ function table (state::ParserState)
 end
 
 
-const table_array_pattern = Regex("[ \t]*([^ \t\r\n]?[^\]\r\n]*)\]\]", Base.PCRE.ANCHORED)
+const table_array_pattern = anchored_regex("[ \t]*([^ \t\r\n]?[^\]\r\n]*)\]\]")
 
 function table_array (state::ParserState)
     m = match(table_array_pattern, state.subject, state.index)
@@ -152,7 +159,7 @@ function table_array (state::ParserState)
 end
 
 
-const key_pattern = Regex("([^\n\r=]*)([\n\r=])", Base.PCRE.ANCHORED)
+const key_pattern = anchored_regex("([^\n\r=]*)([\n\r=])")
 
 function key (state)
     m = match(key_pattern, state.subject, state.index)

--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -1,5 +1,5 @@
 # waiting for official Timestamp support in Julia. Calendar.jl is too slow to load.
-const date_pattern = Regex("(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})Z", Base.PCRE.ANCHORED)
+const date_pattern = anchored_regex("(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})Z")
 
 immutable DateTime
     year::Int

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,1 @@
+include("test.jl")

--- a/test/test.jl
+++ b/test/test.jl
@@ -2,6 +2,7 @@ module TestTOML
 
 using TOML
 using JSON
+using Compat
 
 function parsedate(str::String) #for the tests.
     d = match(TOML.date_pattern, str)
@@ -84,21 +85,21 @@ function test()
     end
 end
 
-jsnval = [
+jsnval = @compat Dict{ASCIIString,Function}(
     "string" =>identity,
     "float"  =>parsefloat,
     "integer"=>parseint,
     "datetime"   => parsedate,
     "array"  => (a -> map(jsn2data, a)),
     "bool"   => (b -> b == "true")
-]
+)
 
 function jsn2data(jsn)
     # println(jsn)
     if "type" in keys(jsn)
         jsnval[jsn["type"]](jsn["value"])
     else
-        {k => jsn2data(v) for (k, v) in jsn}
+        @compat Dict{Any,Any}([k => jsn2data(v) for (k, v) in jsn])
     end
 end
 


### PR DESCRIPTION
All tests pass on v0.3 and v0.4.  Support for v0.2 is dropped, as `Compat.jl` no longer even supports it.