### PR TITLE
Fix string indexing bug

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -40,7 +40,6 @@ function next_non_space! (state::ParserState)
 end
 
 function endlineP (c, state::ParserState) # Where 'P' really is a '?'.
-    if c == '\r' && state.subject[state.index + 1] == '\n'
     if c == '\r' && state.subject[state.index] == '\n'
         nextchar!(state)
     end

--- a/src/util.jl
+++ b/src/util.jl
@@ -41,6 +41,7 @@ end
 
 function endlineP (c, state::ParserState) # Where 'P' really is a '?'.
     if c == '\r' && state.subject[state.index + 1] == '\n'
+    if c == '\r' && state.subject[state.index] == '\n'
         nextchar!(state)
     end
     if c == '\r' || c == '\n'


### PR DESCRIPTION
The `+1` here is wrong since `state.index` represents the location of the _next_ char, and causes failures on windows (or any platform if the files have \r\n line endings)
