### PR TITLE
Fix deprecation warnings on Julia 0.4

### DIFF
--- a/src/TOML.jl
+++ b/src/TOML.jl
@@ -201,7 +201,7 @@ function value(state)
         return false
     elseif (d = match(date_pattern, state.subject, state.index - 1); d != nothing)
         state.index += 19
-        return ymd_hms(map(parseint, d.captures)..., "UTC")
+        return ymd_hms(map(s -> Base.parse(Int, s), d.captures)..., "UTC")
     elseif c == '-' || '0' <= c <= '9'
         state.index -= 1
         return numeric_value(state)
@@ -237,7 +237,7 @@ function string_value(state::ParserState)
             if chr == 'u'
                 num = (nextchar!(state), nextchar!(state), nextchar!(state), nextchar!(state))
                 try
-                    chr = parseint(string(num...), 16)
+                    chr = Base.parse(Int, string(num...), 16)
                 catch
                     _error("Invalid Unicode escape sequence '\\u$(string(num...))'", state)
                 end
@@ -256,7 +256,6 @@ end
 
 
 function numeric_value(state::ParserState)
-    parsenum = parseint
     NumTyp = Int64
     acc = (Char)[]
     firstdigit = 1
@@ -277,14 +276,14 @@ function numeric_value(state::ParserState)
         if last(acc) == '.'
             _error("Malformed number", state)
         end
-        parsenum, NumTyp = parsefloat, Float64
+        NumTyp = Float64
     end
     state.index -= c==:eof ? 0 : 1
 
     num = 0
     try
         numrepr = string(acc...)
-        num = parsenum(NumTyp, numrepr)
+        num = Base.parse(NumTyp, numrepr)
     catch err
         _error("Couldn't parse number ($(repr(err)))", state)
     end

--- a/src/TOML.jl
+++ b/src/TOML.jl
@@ -23,8 +23,8 @@ type ParserState
     cur_tbl::Dict{UTF8String, Any}
     tbl_names::Set{UTF8String}
 
-    function ParserState{T<:Union{AbstractString, Array{UInt8, 1}}}(subject::T)
-        if isa(subject, Union{ByteString, Array{UInt8, 1}}) && !isvalid(UTF8String, subject)
+    function ParserState{T<: @compat Union{AbstractString, Array{UInt8, 1}}}(subject::T)
+        if isa(subject, @compat Union{ByteString, Array{UInt8, 1}}) && !isvalid(UTF8String, subject)
             throw(TOMLError("$T with invalid UTF-8 byte sequence."))
         end
         try
@@ -50,7 +50,7 @@ end
 include("util.jl")
 
 
-function parse(subject::Union{AbstractString, Array{UInt8, 1}})
+function parse(subject:: @compat Union{AbstractString, Array{UInt8, 1}})
     try
         state = ParserState(subject)
         while true
@@ -129,7 +129,7 @@ function table_array(state::ParserState)
         end
         if haskey(tbl, k)
             if i < length(keys)
-                if !isa(tbl[k], Union{Array{Dict{UTF8String, Any}, 1}, Dict{UTF8String, Any}})
+                if !isa(tbl[k], @compat Union{Array{Dict{UTF8String, Any}, 1}, Dict{UTF8String, Any}})
                     _error("Attempt to overwrite key $(join(keys[1:i], '.'))", state)
                 end
                 if isa(tbl[k], Dict)

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,12 +1,12 @@
 DBG = false
 
-macro debug (msg)
+macro debug(msg)
     if DBG
-        :(println ($msg))
+        :(println($msg))
     end
 end
 
-function idem(needle::String, haystack::String, idx)
+function idem(needle::AbstractString, haystack::AbstractString, idx)
     for c1 in needle
         if done(haystack, idx)
             return false
@@ -30,7 +30,7 @@ function nextchar!(state::ParserState)
     char
 end
 
-function next_non_space! (state::ParserState)
+function next_non_space!(state::ParserState)
     while true
         c = nextchar!(state)
         if c != ' ' && c != '\t'
@@ -39,7 +39,7 @@ function next_non_space! (state::ParserState)
     end
 end
 
-function endlineP (c, state::ParserState) # Where 'P' really is a '?'.
+function endlineP(c, state::ParserState) # Where 'P' really is a '?'.
     if c == '\r' && state.subject[state.index + 1] == '\n'
         nextchar!(state)
     end
@@ -51,7 +51,7 @@ function endlineP (c, state::ParserState) # Where 'P' really is a '?'.
     end
 end
 
-function endline! (state::ParserState)
+function endline!(state::ParserState)
     c = next_non_space!(state);
     if endlineP(c, state)
         return
@@ -66,7 +66,7 @@ function endline! (state::ParserState)
     end
 end
 
-function next_non_comment! (state::ParserState)
+function next_non_comment!(state::ParserState)
     local in_comment = false
     while true
         c = nextchar!(state)

--- a/test/test.jl
+++ b/test/test.jl
@@ -7,7 +7,7 @@ using Compat
 function parsedate(str::AbstractString) #for the tests.
     d = match(TOML.date_pattern, str)
     if d == nothing ;; error("Invalid date string.") end
-    TOML.DateTime(map(parseint, d.captures)...)
+    TOML.DateTime(map(s -> parse(Int, s), d.captures)...)
 end
 
 testdir = Base.source_path()[1:end-8]
@@ -87,8 +87,8 @@ end
 
 jsnval = @compat Dict{ASCIIString,Function}(
     "string" =>identity,
-    "float"  =>parsefloat,
-    "integer"=>parseint,
+    "float"  => (s -> parse(Float64, s)),
+    "integer"=> (s -> parse(Int, s)),
     "datetime"   => parsedate,
     "array"  => (a -> map(jsn2data, a)),
     "bool"   => (b -> b == "true")

--- a/test/test.jl
+++ b/test/test.jl
@@ -4,7 +4,7 @@ using TOML
 using JSON
 using Compat
 
-function parsedate(str::String) #for the tests.
+function parsedate(str::AbstractString) #for the tests.
     d = match(TOML.date_pattern, str)
     if d == nothing ;; error("Invalid date string.") end
     TOML.DateTime(map(parseint, d.captures)...)


### PR DESCRIPTION
This makes the output a little nicer, and should help prevent errors on 0.5